### PR TITLE
fix(schedtc): guard against empty calendar event in debug output

### DIFF
--- a/Job.php
+++ b/Job.php
@@ -72,7 +72,9 @@ class Job implements \FreePBX\Job\TaskInterface
 					if ($debug) $next = $calendar->getNextEvent($item['calendar_id'], null, $item['timezone']);
 				}
 				if ($debug) {
-					if ($timeMatch) {
+					if (empty($next)) {
+						$output->writeln("=>No upcoming calendar events");
+					} elseif ($timeMatch) {
 						$output->writeln("=>" . $next['startdate'] . " " . $next['starttime'] . " is now");
 					} else {
 						$output->writeln("=>" . $next['startdate'] . " " . $next['starttime'] . " is not now");

--- a/bin/schedtc.php
+++ b/bin/schedtc.php
@@ -71,7 +71,9 @@ foreach($conditions as $item){
 			if ($debug) $next = $calendar->getNextEvent($item['calendar_id'],null,$item['timezone']);
 		}
 		if ($debug) {
-			if($timeMatch) {
+			if(empty($next)) {
+				tcout($debug, "=>No upcoming calendar events");
+			} elseif($timeMatch) {
 				tcout($debug, "=>".$next['startdate']." ".$next['starttime']." is now");
 			} else {
 				tcout($debug, "=>".$next['startdate']." ".$next['starttime']." is not now");


### PR DESCRIPTION
## Summary

`schedtc.php --debug` crashes with `Undefined array key "startdate"` when processing calendar-mode time conditions that have no upcoming events. The crash terminates the script, preventing **all subsequent time conditions** from being evaluated.

### Root Cause

In the calendar-mode branch of `schedtc.php`, `getNextEventByGroup()` returns `false` and `getNextEvent()` returns `[]` when no upcoming calendar events exist. The debug output block unconditionally accesses `\$next['startdate']` and `\$next['starttime']` without checking whether `\$next` contains valid data. On PHP 8.x (PBXact 17 / Debian 12), this is a fatal error.

### Fix

Add an `empty()` check on `\$next` before accessing its array keys. When no upcoming event exists, display "No upcoming calendar events" — useful diagnostic context instead of a crash.

Applied to both:
- **`bin/schedtc.php`** — actively triggered via `--debug` flag
- **`Job.php`** — defensive fix; `\$debug` is currently hardcoded `false` but the same latent bug exists

### Reproduction

On any PBXact 17 / FreePBX 17 system with a calendar-mode time condition where the linked calendar has no future events:

```bash
php /var/www/html/admin/modules/timeconditions/bin/schedtc.php --debug
```

### Environment

- PBXact 17 / FreePBX 17
- timeconditions 17.0.1.18
- PHP 8.1+ (Debian 12)
- Asterisk 21/22

### Related

- Community thread (same symptom, unresolved): https://community.freepbx.org/t/freepbx-bug-blf-subscriptions/106007
- Companion PR for `Calendar::getNextEventByGroup()` return value inconsistency: submitted to FreePBX/calendar

---

*Discovered during fleet maintenance by Aaron Salsitz (Master Bitherder) at [ICCI, LLC](https://icci.com). Analysis and fix developed with [Claude Code](https://claude.ai/code).*